### PR TITLE
fix for sub 1 SOL prices

### DIFF
--- a/Observer/Handlers/DigitalEyesHandler.cs
+++ b/Observer/Handlers/DigitalEyesHandler.cs
@@ -66,7 +66,7 @@ namespace Observer.Handlers
                             .Aggregate(0UL, (current, innerAmount) => current + (ulong)innerAmount);
 
                         var metadataAccount = _collectionProvider.GetMetadataAccountForMint(nftMint);
-                        var price = (double) ((amount + feeAmount) / MetaplexHelpers.LamportsPerSol);
+                        var price = (double) (100 * (amount + feeAmount) / MetaplexHelpers.LamportsPerSol) / 100;
                     
                         if (metadataAccount != null)
                         {
@@ -93,8 +93,8 @@ namespace Observer.Handlers
                         var data = (string) decodedInstructions[4].Values.GetValueOrDefault("Data");
                         if (from == null || data == null || nftMint == null) break;
 
-                        var price = (double)(MetaplexHelpers.GetPriceFromData(Encoders.Base58.DecodeData(data)) /
-                                             MetaplexHelpers.LamportsPerSol);
+                        var price = (double)(100 * MetaplexHelpers.GetPriceFromData(Encoders.Base58.DecodeData(data)) /
+                                             MetaplexHelpers.LamportsPerSol) /100;
                         var metadataAccount = _collectionProvider.GetMetadataAccountForMint(nftMint);
                         /**/
                         if (metadataAccount != null)

--- a/Observer/Handlers/MonkeyBusinessHandler.cs
+++ b/Observer/Handlers/MonkeyBusinessHandler.cs
@@ -63,7 +63,7 @@ namespace Observer.Handlers
                         if (amount == null || feeAmount == null || from == null || to == null || nftMint == null) break;
 
                         var metadataAccount = _collectionProvider.GetMetadataAccountForMint(nftMint);
-                        var price = (double)  ((ulong) amount + (ulong) feeAmount) / MetaplexHelpers.LamportsPerSol;
+                        var price = (double)  (100 * ((ulong) amount + (ulong) feeAmount) / MetaplexHelpers.LamportsPerSol ) / 100;
                         
                         if (metadataAccount != null)
                         {
@@ -87,8 +87,8 @@ namespace Observer.Handlers
                         var data = (string) decodedInstructions[4].Values.GetValueOrDefault("Data");
                         if (from == null || data == null || nftMint == null) break;
 
-                        var price = (double) (MetaplexHelpers.GetPriceFromData(Encoders.Base58.DecodeData(data)) /
-                                     MetaplexHelpers.LamportsPerSol);
+                        var price = (double) (100 * MetaplexHelpers.GetPriceFromData(Encoders.Base58.DecodeData(data)) /
+                                     MetaplexHelpers.LamportsPerSol) / 100;
                         var metadataAccount = _collectionProvider.GetMetadataAccountForMint(nftMint);
 
                         if (metadataAccount != null)

--- a/Observer/Handlers/SolanartHandler.cs
+++ b/Observer/Handlers/SolanartHandler.cs
@@ -64,7 +64,7 @@ namespace Observer.Handlers
                         var nftMint = (PublicKey) decodedInstructions[0].InnerInstructions[3].Values.GetValueOrDefault("Mint");
                         if (amount == null || feeAmount == null || from == null || to == null || nftMint == null) break;
                         var metadataAccount = _collectionProvider.GetMetadataAccountForMint(nftMint);
-                        var price = (double) ((ulong) amount + (ulong) feeAmount) / MetaplexHelpers.LamportsPerSol;
+                        var price = (double) ( 100 * ((ulong) amount + (ulong) feeAmount) / MetaplexHelpers.LamportsPerSol) / 100;
                     
                         if (metadataAccount != null)
                         {
@@ -151,7 +151,7 @@ namespace Observer.Handlers
                 .Where(innerAmount => innerAmount != null)
                 .Aggregate(0UL, (current, innerAmount) => current + (ulong)innerAmount);
             
-            var price = (double) ((ulong) amount + (ulong) feeAmount + otherAmounts)/ MetaplexHelpers.LamportsPerSol;
+            var price = (double) (100 * ((ulong) amount + (ulong) feeAmount + otherAmounts)/ MetaplexHelpers.LamportsPerSol) / 100;
         
             if (metadataAccount != null)
             {


### PR DESCRIPTION
Current code displayed 0SOL price for all sub 1 SOL listings and sells. Qucick fix is to multiply the `ulong` by 100 and then divide resultant `double` by 100
eg.:
```
var price = (double)((amount + feeAmount) / MetaplexHelpers.LamportsPerSol);
```

changed to 

```
var price = (double)(100*(amount + feeAmount) / MetaplexHelpers.LamportsPerSol)/100;
```